### PR TITLE
Improve pyproject.toml metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,6 @@ tbump = "^6.3.2"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+addopts = "-v --cov=classyconf --cov-report=term --cov-report=xml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ description = "Extensible library for separation of settings from code."
 authors = ["Hernan Lozano <hernantz@gmail.com>"]
 license = "MIT"
 readme = "README.md"
-homepage = https://github.com/hernantz/classyconf
-repository = https://github.com/hernantz/classyconf
-documentation = https://classyconf.readthedocs.io/en/latest/
+homepage = "https://github.com/hernantz/classyconf"
+repository = "https://github.com/hernantz/classyconf"
+documentation = "https://classyconf.readthedocs.io/en/latest/"
 classifiers = [
     "Topic :: Software Development :: Build Tools",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,22 @@ version = "0.5.1"
 description = "Extensible library for separation of settings from code."
 authors = ["Hernan Lozano <hernantz@gmail.com>"]
 license = "MIT"
+readme = "README.md"
+homepage = https://github.com/hernantz/classyconf
+repository = https://github.com/hernantz/classyconf
+documentation = https://classyconf.readthedocs.io/en/latest/
+classifiers = [
+    "Topic :: Software Development :: Build Tools",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: System :: Archiving :: Packaging",
+    "Topic :: Utilities",
+    "Intended Audience :: Developers",
+    "Development Status :: 5 - Production/Stable",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9"
+]
 
 [tool.poetry.dependencies]
 python = "^3.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,3 @@ include_package_data = True
 
 [wheel]
 universal = 1
-
-[tool:pytest]
-addopts = -v --cov=classyconf --cov-report=term --cov-report=xml


### PR DESCRIPTION
Currently most of the metadata is in the `setup.cfg` file.